### PR TITLE
[Native] FeagiAgentClient implementation over JNI (#31)

### DIFF
--- a/sdk-native/build.gradle.kts
+++ b/sdk-native/build.gradle.kts
@@ -10,8 +10,13 @@ java {
 
 dependencies {
     api(project(":sdk-core"))
+
+    testImplementation("org.junit.jupiter:junit-jupiter:5.10.2")
 }
 
+tasks.test {
+    useJUnitPlatform()
+}
 val nativeBuildDir = layout.buildDirectory.dir("native")
 val cmakeSourceDir = file("src/main/cpp")
 

--- a/sdk-native/src/main/cpp/feagi_jni.cpp
+++ b/sdk-native/src/main/cpp/feagi_jni.cpp
@@ -5,3 +5,33 @@ extern "C" JNIEXPORT jint JNICALL
 Java_io_feagi_sdk_nativeffi_FeagiNativeBindings_feagiAbiVersion(JNIEnv*, jclass) {
     return (jint)feagi_abi_version();
 }
+
+// Copies bytes out of a FeagiByteBufferHandle into a new Java byte array.
+// Called by NativeFeagiAgentClient.pollMotorBytes() to materialise the motor frame.
+JNIEXPORT jbyteArray JNICALL
+Java_io_feagi_sdk_nativeffi_NativeFeagiAgentClient_copyNativeBuffer(
+        JNIEnv* env, jclass /*cls*/,
+        jlong   bufHandle,
+        jint    length) {
+
+    const FeagiByteBufferHandle* buf = JLONG_TO_PTR(const FeagiByteBufferHandle, bufHandle);
+    if (buf == nullptr || length <= 0) {
+        return nullptr;
+    }
+
+    const uint8_t* ptr = feagi_buffer_ptr(buf);
+    if (ptr == nullptr) {
+        return nullptr;
+    }
+
+    jbyteArray result = env->NewByteArray(length);
+    if (result == nullptr) {
+        return nullptr;   // OutOfMemoryError already thrown by JVM
+    }
+
+    env->SetByteArrayRegion(
+        result, 0, length,
+        reinterpret_cast<const jbyte*>(ptr));
+
+    return result;
+}

--- a/sdk-native/src/main/java/io/feagi/sdk/nativeffi/NativeFeagiAgentClient.java
+++ b/sdk-native/src/main/java/io/feagi/sdk/nativeffi/NativeFeagiAgentClient.java
@@ -1,0 +1,486 @@
+/*
+ * Copyright 2026 Neuraville Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.feagi.sdk.nativeffi;
+
+import io.feagi.sdk.core.AgentCapabilities;
+import io.feagi.sdk.core.AgentConfig;
+import io.feagi.sdk.core.FeagiAgentClient;
+import io.feagi.sdk.core.FeagiResolution;
+import io.feagi.sdk.core.FeagiSdkException;
+import io.feagi.sdk.core.MotorCapability;
+import io.feagi.sdk.core.MotorUnitSpec;
+import io.feagi.sdk.core.SensoryCapability;
+import io.feagi.sdk.core.SensorySocketConfig;
+import io.feagi.sdk.core.VisionCapability;
+import io.feagi.sdk.core.VisualizationCapability;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * {@link FeagiAgentClient} implementation backed by the Rust feagi-java-ffi library via JNI.
+ *
+ * <h2>Lifecycle</h2>
+ * <pre>{@code
+ * AgentConfig config = new AgentConfig(...);
+ *
+ * try (NativeFeagiAgentClient client = new NativeFeagiAgentClient(config)) {
+ *     client.connect();
+ *     client.sendSensoryBytes(payload);
+ *     byte[] motor = client.pollMotorBytes();
+ * }
+ * }</pre>
+ *
+ * <h2>Handle ownership</h2>
+ * <ul>
+ *   <li>{@code cfgHandle} — allocated in {@link #connect()}, freed in the same call after
+ *       the client handle is created.</li>
+ *   <li>{@code clientHandle} — allocated by {@link #connect()}, freed by {@link #close()}.</li>
+ * </ul>
+ *
+ * <h2>Thread safety</h2>
+ * {@link #sendSensoryBytes} and {@link #pollMotorBytes} are safe to call from any thread
+ * after {@link #connect()} returns. {@link #connect()} and {@link #close()} must not be
+ * called concurrently.
+ */
+public final class NativeFeagiAgentClient implements FeagiAgentClient {
+
+    private static final Logger LOG = Logger.getLogger(NativeFeagiAgentClient.class.getName());
+    private static final long NULL_HANDLE = 0L;
+
+    private final AgentConfig config;
+
+    /**
+     * Opaque pointer to the native {@code FeagiAgentClientHandle}.
+     * Set by {@link #connect()}, cleared by {@link #close()}.
+     */
+    private final AtomicLong clientHandle = new AtomicLong(NULL_HANDLE);
+
+    private volatile boolean connected = false;
+
+    // ── Construction ───────────────────────────────────────────────────────────
+
+    /**
+     * Create a new client. The native library must already be loaded via
+     * {@link FeagiNativeLibrary#loadAndVerify(String)} before constructing this object.
+     *
+     * @param config fully-populated agent configuration; must not be null
+     */
+    public NativeFeagiAgentClient(AgentConfig config) {
+        if (config == null) {
+            throw new IllegalArgumentException("config must not be null");
+        }
+        this.config = config;
+    }
+
+    // ── FeagiAgentClient ───────────────────────────────────────────────────────
+
+    /**
+     * Connect and register the agent with FEAGI.
+     *
+     * <p>Translates every field of {@link AgentConfig} into native config calls — no
+     * hardcoded host/ports/timeouts anywhere in this method.
+     *
+     * @throws FeagiSdkException     if native config, client creation, or connection fails
+     * @throws IllegalStateException if already connected
+     */
+    @Override
+    public void connect() {
+        if (connected) {
+            throw new IllegalStateException("Already connected. Call close() first.");
+        }
+
+        // ── 1. Allocate native config handle ──────────────────────────────────
+        long cfgHandle = FeagiNativeBindings.feagiConfigNew(
+                config.agentId(),
+                config.agentType().ordinal());
+        if (cfgHandle == NULL_HANDLE) {
+            throw new FeagiSdkException(
+                    "feagiConfigNew failed for agent '" + config.agentId() + "': "
+                    + nativeError());
+        }
+
+        try {
+            // ── 2. Endpoints ──────────────────────────────────────────────────
+            applyEndpoints(cfgHandle);
+
+            // ── 3. Timing / retry ─────────────────────────────────────────────
+            applyTimingConfig(cfgHandle);
+
+            // ── 4. Sensory socket ─────────────────────────────────────────────
+            applySensorySocketConfig(cfgHandle);
+
+            // ── 5. Capabilities ───────────────────────────────────────────────
+            applyCapabilities(cfgHandle);
+
+            // ── 6. Rust-side validation ───────────────────────────────────────
+            int validateStatus = FeagiNativeBindings.feagiConfigValidate(cfgHandle);
+            checkStatus(validateStatus, "feagiConfigValidate");
+
+            // ── 7. Create native client ───────────────────────────────────────
+            long[] outClient = new long[1];
+            int newStatus = FeagiNativeBindings.feagiClientNew(cfgHandle, outClient);
+            checkStatus(newStatus, "feagiClientNew");
+
+            long handle = outClient[0];
+            if (handle == NULL_HANDLE) {
+                throw new FeagiSdkException(
+                        "feagiClientNew returned null handle: " + nativeError());
+            }
+            clientHandle.set(handle);
+
+        } finally {
+            // Config handle is only needed during client creation — free it now.
+            FeagiNativeBindings.feagiConfigFree(cfgHandle);
+        }
+
+        // ── 8. Connect and register ───────────────────────────────────────────
+        int connectStatus = FeagiNativeBindings.feagiClientConnect(clientHandle.get());
+        if (connectStatus != FeagiNativeBindings.FeagiStatus.OK.code()) {
+            long h = clientHandle.getAndSet(NULL_HANDLE);
+            FeagiNativeBindings.feagiClientFree(h);
+            throw new FeagiSdkException(
+                    "feagiClientConnect failed (status=" + connectStatus + "): " + nativeError());
+        }
+
+        connected = true;
+        LOG.info("NativeFeagiAgentClient connected: agentId=" + config.agentId()
+                + " type=" + config.agentType()
+                + " registration=" + config.endpoints().registrationEndpoint());
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Uses try-send semantics — frames may be silently dropped under ZMQ backpressure
+     * (real-time contract, no implicit buffering).
+     */
+    @Override
+    public void sendSensoryBytes(byte[] payload) {
+        if (payload == null || payload.length == 0) {
+            throw new IllegalArgumentException("payload must not be null or empty");
+        }
+        requireConnected("sendSensoryBytes");
+
+        boolean[] outSent = new boolean[1];
+        int status = FeagiNativeBindings.feagiClientTrySendSensoryBytes(
+                clientHandle.get(), payload, outSent);
+
+        if (status != FeagiNativeBindings.FeagiStatus.OK.code()) {
+            throw new FeagiSdkException(
+                    "sendSensoryBytes failed (status=" + status + "): " + nativeError());
+        }
+        if (!outSent[0]) {
+            LOG.fine("sendSensoryBytes: frame dropped (backpressure)");
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Non-blocking. Returns {@code null} if no motor frame is available yet.
+     */
+    @Override
+    public byte[] pollMotorBytes() {
+        requireConnected("pollMotorBytes");
+
+        long[] outBufHandle = new long[1];
+        boolean[] outHasData = new boolean[1];
+
+        int status = FeagiNativeBindings.feagiClientReceiveMotorBuffer(
+                clientHandle.get(), outBufHandle, outHasData);
+
+        if (status != FeagiNativeBindings.FeagiStatus.OK.code()) {
+            throw new FeagiSdkException(
+                    "pollMotorBytes failed (status=" + status + "): " + nativeError());
+        }
+
+        if (!outHasData[0] || outBufHandle[0] == NULL_HANDLE) {
+            return null;
+        }
+
+        long bufHandle = outBufHandle[0];
+        try {
+            long len = FeagiNativeBindings.feagiBufferLen(bufHandle);
+            if (len <= 0 || len > Integer.MAX_VALUE) {
+                return null;
+            }
+            return copyNativeBuffer(bufHandle, (int) len);
+        } finally {
+            FeagiNativeBindings.feagiBufferFree(bufHandle);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Idempotent — safe to call multiple times.
+     */
+    @Override
+    public void close() {
+        connected = false;
+        long handle = clientHandle.getAndSet(NULL_HANDLE);
+        if (handle != NULL_HANDLE) {
+            try {
+                FeagiNativeBindings.feagiClientFree(handle);
+            } catch (Exception e) {
+                LOG.log(Level.WARNING, "Error freeing native client handle", e);
+            }
+            LOG.info("NativeFeagiAgentClient closed: agentId=" + config.agentId());
+        }
+    }
+
+    // ── Config helpers ─────────────────────────────────────────────────────────
+
+    private void applyEndpoints(long cfgHandle) {
+        var ep = config.endpoints();
+
+        checkStatus(
+                FeagiNativeBindings.feagiConfigSetRegistrationEndpoint(
+                        cfgHandle, ep.registrationEndpoint()),
+                "feagiConfigSetRegistrationEndpoint");
+
+        if (ep.sensoryEndpoint() != null) {
+            checkStatus(
+                    FeagiNativeBindings.feagiConfigSetSensoryEndpoint(
+                            cfgHandle, ep.sensoryEndpoint()),
+                    "feagiConfigSetSensoryEndpoint");
+        }
+        if (ep.motorEndpoint() != null) {
+            checkStatus(
+                    FeagiNativeBindings.feagiConfigSetMotorEndpoint(
+                            cfgHandle, ep.motorEndpoint()),
+                    "feagiConfigSetMotorEndpoint");
+        }
+        if (ep.visualizationEndpoint() != null) {
+            checkStatus(
+                    FeagiNativeBindings.feagiConfigSetVisualizationEndpoint(
+                            cfgHandle, ep.visualizationEndpoint()),
+                    "feagiConfigSetVisualizationEndpoint");
+        }
+        if (ep.controlEndpoint() != null) {
+            checkStatus(
+                    FeagiNativeBindings.feagiConfigSetControlEndpoint(
+                            cfgHandle, ep.controlEndpoint()),
+                    "feagiConfigSetControlEndpoint");
+        }
+    }
+
+    private void applyTimingConfig(long cfgHandle) {
+        double heartbeatSecs = config.heartbeatInterval().toMillis() / 1000.0;
+        checkStatus(
+                FeagiNativeBindings.feagiConfigSetHeartbeatIntervalSeconds(
+                        cfgHandle, heartbeatSecs),
+                "feagiConfigSetHeartbeatIntervalSeconds");
+
+        checkStatus(
+                FeagiNativeBindings.feagiConfigSetConnectionTimeoutMs(
+                        cfgHandle, config.connectionTimeout().toMillis()),
+                "feagiConfigSetConnectionTimeoutMs");
+
+        checkStatus(
+                FeagiNativeBindings.feagiConfigSetRegistrationRetries(
+                        cfgHandle, config.registrationRetries()),
+                "feagiConfigSetRegistrationRetries");
+
+        checkStatus(
+                FeagiNativeBindings.feagiConfigSetRetryBackoffMs(
+                        cfgHandle, config.retryBackoff().toMillis()),
+                "feagiConfigSetRetryBackoffMs");
+    }
+
+    private void applySensorySocketConfig(long cfgHandle) {
+        SensorySocketConfig sc = config.sensorySocketConfig();
+        checkStatus(
+                FeagiNativeBindings.feagiConfigSetSensorySocketConfig(
+                        cfgHandle, sc.sendHwm(), sc.lingerMs(), sc.immediate()),
+                "feagiConfigSetSensorySocketConfig");
+    }
+
+    private void applyCapabilities(long cfgHandle) {
+        AgentCapabilities caps = config.capabilities();
+        applyVisionCapability(cfgHandle, caps.vision());
+        applyMotorCapability(cfgHandle, caps.motor());
+        applyVisualizationCapability(cfgHandle, caps.visualization());
+        applySensoryCapability(cfgHandle, caps.sensory());
+
+        for (Map.Entry<String, String> entry : caps.customCapabilitiesJson().entrySet()) {
+            checkStatus(
+                    FeagiNativeBindings.feagiConfigSetCustomCapabilityJson(
+                            cfgHandle, entry.getKey(), entry.getValue()),
+                    "feagiConfigSetCustomCapabilityJson[" + entry.getKey() + "]");
+        }
+    }
+
+    private void applyVisionCapability(long cfgHandle, VisionCapability vision) {
+        if (vision == null) return;
+
+        if (vision.targetCorticalArea() != null) {
+            // Option A: explicit cortical area string
+            checkStatus(
+                    FeagiNativeBindings.feagiConfigSetVisionCapability(
+                            cfgHandle,
+                            vision.modality(),
+                            vision.width(),
+                            vision.height(),
+                            vision.channels(),
+                            vision.targetCorticalArea()),
+                    "feagiConfigSetVisionCapability");
+        } else {
+            // Option B: semantic SensoryUnit enum + group index
+            // ordinal() matches the FeagiSensoryUnit C enum values by contract
+            checkStatus(
+                    FeagiNativeBindings.feagiConfigSetVisionUnit(
+                            cfgHandle,
+                            vision.modality(),
+                            vision.width(),
+                            vision.height(),
+                            vision.channels(),
+                            vision.unit().ordinal(),   // SensoryUnit → int
+                            vision.group()),            // Integer guaranteed non-null here
+                    "feagiConfigSetVisionUnit");
+        }
+    }
+
+    private void applyMotorCapability(long cfgHandle, MotorCapability motor) {
+        if (motor == null) return;
+
+        if (motor.sourceCorticalAreas() != null) {
+            // Option A: list of cortical area IDs → JSON string array
+            checkStatus(
+                    FeagiNativeBindings.feagiConfigSetMotorCapability(
+                            cfgHandle,
+                            motor.modality(),
+                            motor.outputCount(),
+                            toJsonStringArray(motor.sourceCorticalAreas())),
+                    "feagiConfigSetMotorCapability");
+
+        } else if (motor.sourceUnits() != null) {
+            // Option C: multiple MotorUnitSpec → JSON array of {unit, group} objects
+            checkStatus(
+                    FeagiNativeBindings.feagiConfigSetMotorUnitsJson(
+                            cfgHandle,
+                            motor.modality(),
+                            motor.outputCount(),
+                            motorUnitSpecsToJson(motor.sourceUnits())),
+                    "feagiConfigSetMotorUnitsJson");
+
+        } else {
+            // Option B: single MotorUnit enum + group index
+            // ordinal() matches the FeagiMotorUnit C enum values by contract
+            checkStatus(
+                    FeagiNativeBindings.feagiConfigSetMotorUnit(
+                            cfgHandle,
+                            motor.modality(),
+                            motor.outputCount(),
+                            motor.unit().ordinal(),    // MotorUnit → int
+                            motor.group()),             // Integer guaranteed non-null here
+                    "feagiConfigSetMotorUnit");
+        }
+    }
+
+    private void applyVisualizationCapability(long cfgHandle, VisualizationCapability viz) {
+        if (viz == null) return;
+
+        // FeagiResolution is nullable — unpack safely
+        FeagiResolution res = viz.resolution();
+        boolean hasResolution = res != null;
+        int resWidth  = hasResolution ? res.width()  : 0;
+        int resHeight = hasResolution ? res.height() : 0;
+
+        // refreshRateHz() returns Double (nullable)
+        Double refreshRate = viz.refreshRateHz();
+        boolean hasRefreshRate = refreshRate != null;
+        double refreshRateHz = hasRefreshRate ? refreshRate : 0.0;
+
+        checkStatus(
+                FeagiNativeBindings.feagiConfigSetVisualizationCapability(
+                        cfgHandle,
+                        viz.visualizationType(),
+                        hasResolution,
+                        resWidth,
+                        resHeight,
+                        hasRefreshRate,
+                        refreshRateHz,
+                        viz.bridgeProxy()),
+                "feagiConfigSetVisualizationCapability");
+    }
+
+    private void applySensoryCapability(long cfgHandle, SensoryCapability sensory) {
+        if (sensory == null) return;
+
+        checkStatus(
+                FeagiNativeBindings.feagiConfigSetSensoryCapability(
+                        cfgHandle,
+                        sensory.rateHz(),
+                        sensory.shmPath()),   // nullable — JNI bridge handles null as NULL ptr
+                "feagiConfigSetSensoryCapability");
+    }
+
+    // ── JSON serialization ─────────────────────────────────────────────────────
+
+    /**
+     * Serialize to minimal JSON string array, e.g. {@code ["v1_motor","v2_drive"]}.
+     * No external JSON library required — cortical area IDs are safe ASCII identifiers.
+     */
+    private static String toJsonStringArray(List<String> items) {
+        StringBuilder sb = new StringBuilder("[");
+        for (int i = 0; i < items.size(); i++) {
+            sb.append('"')
+              .append(items.get(i).replace("\\", "\\\\").replace("\"", "\\\""))
+              .append('"');
+            if (i < items.size() - 1) sb.append(',');
+        }
+        return sb.append(']').toString();
+    }
+
+    /**
+     * Serialize to JSON array of unit/group objects, e.g.
+     * {@code [{"unit":0,"group":1},{"unit":2,"group":0}]}.
+     * {@link MotorUnit#ordinal()} matches FeagiMotorUnit C enum values by contract.
+     */
+    private static String motorUnitSpecsToJson(List<MotorUnitSpec> specs) {
+        StringBuilder sb = new StringBuilder("[");
+        for (int i = 0; i < specs.size(); i++) {
+            MotorUnitSpec s = specs.get(i);
+            sb.append("{\"unit\":").append(s.unit().ordinal())
+              .append(",\"group\":").append(s.group())
+              .append('}');
+            if (i < specs.size() - 1) sb.append(',');
+        }
+        return sb.append(']').toString();
+    }
+
+    // ── Native helpers ─────────────────────────────────────────────────────────
+
+    /**
+     * Copy bytes out of a native {@code FeagiByteBufferHandle} into a Java byte array.
+     * The buffer handle must remain valid during this call; caller frees it afterward.
+     */
+    private static native byte[] copyNativeBuffer(long bufHandle, int length);
+
+    private void requireConnected(String method) {
+        if (!connected || clientHandle.get() == NULL_HANDLE) {
+            throw new IllegalStateException(
+                    method + "() called but client is not connected. Call connect() first.");
+        }
+    }
+
+    private static void checkStatus(int status, String operation) {
+        if (status != FeagiNativeBindings.FeagiStatus.OK.code()) {
+            throw new FeagiSdkException(
+                    operation + " failed (status=" + status + "): " + nativeError());
+        }
+    }
+
+    private static String nativeError() {
+        String msg = FeagiNativeBindings.feagiLastErrorMessage();
+        return msg != null ? msg : "(no native error message)";
+    }
+}

--- a/sdk-native/src/test/java/io/feagi/sdk/nativeffi/NativeFeagiAgentClientTest.java
+++ b/sdk-native/src/test/java/io/feagi/sdk/nativeffi/NativeFeagiAgentClientTest.java
@@ -1,0 +1,224 @@
+package io.feagi.sdk.nativeffi;
+
+import io.feagi.sdk.core.*;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for NativeFeagiAgentClient that do NOT require the native library.
+ *
+ * <p>Covers:
+ * <ul>
+ *   <li>Null config rejection at construction time</li>
+ *   <li>Guard-rails on sendSensoryBytes / pollMotorBytes before connect()</li>
+ *   <li>Null / empty payload rejection on sendSensoryBytes</li>
+ *   <li>Idempotent close()</li>
+ * </ul>
+ *
+ * <p>Integration tests (requiring the native library) live in the smoke test suite.
+ */
+class NativeFeagiAgentClientTest {
+
+    // ── Test fixture ───────────────────────────────────────────────────────────
+
+    private static AgentConfig minimalConfig() {
+        FeagiEndpoints endpoints = new FeagiEndpoints(
+                "tcp://localhost:30001",   // registration — required
+                "tcp://localhost:5558",    // sensory
+                "tcp://localhost:5564",    // motor
+                null,                      // visualization — not used
+                null                       // control — not used
+        );
+
+        // VisionCapability.fromUnit() — Option B: SensoryUnit enum + group
+        VisionCapability vision = VisionCapability.fromUnit(
+                "camera",
+                320, 240, 3,
+                SensoryUnit.VISION,
+                0
+        );
+
+        // MotorCapability.fromUnit() — Option B: MotorUnit enum + group
+        MotorCapability motor = MotorCapability.fromUnit(
+                "drive",
+                4,
+                MotorUnit.ROTARY_MOTOR,
+                0
+        );
+
+        AgentCapabilities caps = AgentCapabilities.builder()
+                .vision(vision)
+                .motor(motor)
+                .build();
+
+        return new AgentConfig(
+                "test-agent",
+                AgentType.BOTH,
+                endpoints,
+                caps,
+                Duration.ofSeconds(5),      // heartbeatInterval
+                Duration.ofSeconds(10),     // connectionTimeout
+                3,                          // registrationRetries
+                Duration.ofMillis(500),     // retryBackoff
+                new SensorySocketConfig(1000, 0, true)
+        );
+    }
+
+    // ── Construction ───────────────────────────────────────────────────────────
+
+    @Test
+    void constructor_rejectsNullConfig() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new NativeFeagiAgentClient(null));
+    }
+
+    @Test
+    void constructor_acceptsValidConfig() {
+        assertDoesNotThrow(() -> new NativeFeagiAgentClient(minimalConfig()));
+    }
+
+    // ── Guard-rails before connect() ───────────────────────────────────────────
+
+    @Test
+    void sendSensoryBytes_beforeConnect_throwsIllegalState() {
+        var client = new NativeFeagiAgentClient(minimalConfig());
+        assertThrows(IllegalStateException.class,
+                () -> client.sendSensoryBytes(new byte[]{1, 2, 3}));
+    }
+
+    @Test
+    void pollMotorBytes_beforeConnect_throwsIllegalState() {
+        var client = new NativeFeagiAgentClient(minimalConfig());
+        assertThrows(IllegalStateException.class, client::pollMotorBytes);
+    }
+
+    // ── Input validation ───────────────────────────────────────────────────────
+
+    @Test
+    void sendSensoryBytes_rejectsNullPayload() {
+        var client = new NativeFeagiAgentClient(minimalConfig());
+        // Null payload is rejected before connection state is checked
+        assertThrows(IllegalArgumentException.class,
+                () -> client.sendSensoryBytes(null));
+    }
+
+    @Test
+    void sendSensoryBytes_rejectsEmptyPayload() {
+        var client = new NativeFeagiAgentClient(minimalConfig());
+        assertThrows(IllegalArgumentException.class,
+                () -> client.sendSensoryBytes(new byte[0]));
+    }
+
+    // ── Idempotent close ───────────────────────────────────────────────────────
+
+    @Test
+    void close_beforeConnect_doesNotThrow() {
+        var client = new NativeFeagiAgentClient(minimalConfig());
+        assertDoesNotThrow(client::close);
+    }
+
+    @Test
+    void close_isIdempotent() {
+        var client = new NativeFeagiAgentClient(minimalConfig());
+        assertDoesNotThrow(client::close);
+        assertDoesNotThrow(client::close);
+    }
+
+    // ── Config variations ──────────────────────────────────────────────────────
+
+    @Test
+    void constructor_acceptsVisionFromTargetArea() {
+        FeagiEndpoints endpoints = new FeagiEndpoints(
+                "tcp://localhost:30001",
+                "tcp://localhost:5558",
+                null, null, null
+        );
+
+        VisionCapability vision = VisionCapability.fromTargetArea(
+                "camera", 640, 480, 3, "vision_cortex"
+        );
+
+        AgentCapabilities caps = AgentCapabilities.builder().vision(vision).build();
+
+        AgentConfig config = new AgentConfig(
+                "vision-agent",
+                AgentType.SENSORY,
+                endpoints,
+                caps,
+                Duration.ofSeconds(5),
+                Duration.ofSeconds(10),
+                3,
+                Duration.ofMillis(500),
+                new SensorySocketConfig(1000, 0, true)
+        );
+
+        assertDoesNotThrow(() -> new NativeFeagiAgentClient(config));
+    }
+
+    @Test
+    void constructor_acceptsMotorFromCorticalAreas() {
+        FeagiEndpoints endpoints = new FeagiEndpoints(
+                "tcp://localhost:30001",
+                null,
+                "tcp://localhost:5564",
+                null, null
+        );
+
+        MotorCapability motor = MotorCapability.fromCorticalAreas(
+                "servo", 2, java.util.List.of("m_servo_0", "m_servo_1")
+        );
+
+        AgentCapabilities caps = AgentCapabilities.builder().motor(motor).build();
+
+        AgentConfig config = new AgentConfig(
+                "motor-agent",
+                AgentType.MOTOR,
+                endpoints,
+                caps,
+                Duration.ofSeconds(5),
+                Duration.ofSeconds(10),
+                3,
+                Duration.ofMillis(500),
+                new SensorySocketConfig(1000, 0, true)
+        );
+
+        assertDoesNotThrow(() -> new NativeFeagiAgentClient(config));
+    }
+
+    @Test
+    void constructor_acceptsMotorFromUnits() {
+        FeagiEndpoints endpoints = new FeagiEndpoints(
+                "tcp://localhost:30001",
+                null,
+                "tcp://localhost:5564",
+                null, null
+        );
+
+        MotorCapability motor = MotorCapability.fromUnits(
+                "mixed", 4,
+                java.util.List.of(
+                        new MotorUnitSpec(MotorUnit.ROTARY_MOTOR, 0),
+                        new MotorUnitSpec(MotorUnit.POSITIONAL_SERVO, 1)
+                )
+        );
+
+        AgentCapabilities caps = AgentCapabilities.builder().motor(motor).build();
+
+        AgentConfig config = new AgentConfig(
+                "multi-motor-agent",
+                AgentType.MOTOR,
+                endpoints,
+                caps,
+                Duration.ofSeconds(5),
+                Duration.ofSeconds(10),
+                3,
+                Duration.ofMillis(500),
+                new SensorySocketConfig(1000, 0, true)
+        );
+
+        assertDoesNotThrow(() -> new NativeFeagiAgentClient(config));
+    }
+}


### PR DESCRIPTION
## Summary

Implements `FeagiAgentClient` over JNI using the `feagi_java_ffi` C ABI.

This implementation:
- Uses `AgentConfig` for all endpoints and timing configuration
- Does not hardcode host, ports, or timeouts
- Wraps all client lifecycle operations:
  - connect()
  - sendSensoryBytes()
  - pollMotorBytes()
  - close()

## Native Layer

- Added JNI bridge (`feagi_jni.cpp`)
- Opaque pointer encoding via jlong
- Safe string conversions (UTF-8)
- Safe buffer copy for motor frames
- ABI handshake verification via `NativeSmokeTest`

## Tests

- Unit tests for `NativeFeagiAgentClient` (no native required)
- Smoke test for JNI library load + ABI handshake

## Acceptance Criteria

✔ Implements `FeagiAgentClient` via JNI  
✔ Uses `AgentConfig` for all configuration  
✔ No hardcoded endpoints or timeouts  
✔ JNI bridge builds on Windows (MSVC)  
✔ Smoke test passes  

Closes #31